### PR TITLE
[eslint-config] Add a message for confusing-browser-globals

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/variables.js
+++ b/packages/eslint-config-airbnb-base/rules/variables.js
@@ -28,7 +28,15 @@ module.exports = {
         message:
           'Use Number.isNaN instead https://github.com/airbnb/javascript#standard-library--isnan',
       },
-    ].concat(confusingBrowserGlobals),
+    ].concat(confusingBrowserGlobals.map(function (g) {
+      return {
+        name: g,
+        message:
+          "Use window." +
+          g +
+          " instead. https://github.com/facebook/create-react-app/blob/main/packages/confusing-browser-globals/README.md",
+      };
+    })),
 
     // disallow declaration of variables already declared in the outer scope
     'no-shadow': 'error',


### PR DESCRIPTION
I suggest adding a message for confusing-browser-globals. Currently, it only says you shouldn't use this global variable which is confusing.